### PR TITLE
only load about:blank when option "Pause Webview" is selected

### DIFF
--- a/app/src/main/java/de/vier_bier/habpanelviewer/MainActivity.java
+++ b/app/src/main/java/de/vier_bier/habpanelviewer/MainActivity.java
@@ -295,7 +295,11 @@ public class MainActivity extends ScreenControllingActivity
             mCommandQueue.addHandler(new InternalCommandHandler(this, mMotionDetector, mServerConnection));
             mCommandQueue.addHandler(new AdminHandler(this));
             mCommandQueue.addHandler(new BluetoothHandler(this, (BluetoothManager) getSystemService(BLUETOOTH_SERVICE)));
-            mCommandQueue.addHandler(new ScreenHandler((PowerManager) getSystemService(POWER_SERVICE), this, () -> mWebView.post(() -> mWebView.pause())));
+            boolean pauseWebview = prefs.getBoolean(Constants.PREF_PAUSE_WEBVIEW, false);
+            if (pauseWebview)
+                mCommandQueue.addHandler(new ScreenHandler((PowerManager) getSystemService(POWER_SERVICE), this, () -> mWebView.post(() -> mWebView.pause())));
+            else
+                mCommandQueue.addHandler(new ScreenHandler((PowerManager) getSystemService(POWER_SERVICE), this, null));
             mCommandQueue.addHandler(new VolumeHandler(this, (AudioManager) getSystemService(Context.AUDIO_SERVICE)));
             mCommandQueue.addHandler(new NotificationHandler(this));
             mCommandQueue.addHandler(new TtsHandler(this));

--- a/app/src/main/java/de/vier_bier/habpanelviewer/command/ScreenHandler.java
+++ b/app/src/main/java/de/vier_bier/habpanelviewer/command/ScreenHandler.java
@@ -95,7 +95,7 @@ public class ScreenHandler implements ICommandHandler {
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.putExtra(Constants.INTENT_FLAG_DIM, dim);
         intent.putExtra(Constants.INTENT_FLAG_KEEP_SCREEN_ON, mKeepScreenOn);
-        if (dim) {
+        if (dim && mDimListener != null) {
             mDimListener.deviceDimming();
         }
         mActivity.startActivityForResult(intent, 0);


### PR DESCRIPTION
When dimming the screen the "about:blank" page is only loaded, when the option "Pause Webview" is selected. 